### PR TITLE
Allow Laravel 13 (`^13.0`)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php" : ">=7.0.0",
-        "illuminate/database": "^5.7|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/support": "^5.7|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0"
+        "illuminate/database": "^5.7|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^5.7|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",


### PR DESCRIPTION
## What

Add `^13.0` to `illuminate/database` and `illuminate/support` constraints in `composer.json`.

## Why

Used (transitively via `padosoftcms/padosoftcms-admin`) by [gescat-laravel](https://github.com/padosoft/gescat-laravel) on branch `shift-174733` (upgrade Laravel 12 → 13).

## Compatibility

Additive only — no breaking changes. The `|^13.0` is appended after the existing range.

## Patch

See [7860acb](https://github.com/luca9692/laravel-sluggable/commit/7860acb65765bcd95d99b97a55072c6b53caa713) — 2 lines changed.